### PR TITLE
Cards display geolocation categories

### DIFF
--- a/builder/make_cards.py
+++ b/builder/make_cards.py
@@ -176,6 +176,19 @@ def dict_to_html(card, category, colour):
         out += "\n" + INDENT
         out += "</div>"
     
+    # add locations at bottom of card.
+    if locations:
+        out += "\n\n" + INDENT
+        out += "<div class=\"beans\">"
+        for loc in locations:
+            out += "\n" + 2 * INDENT
+            out += "<div class=\"bean " + colour + " darken-4 "
+            out += colour + "-text text-lighten-3\">"
+            out += "\n" + 3 * INDENT
+            out += loc
+            out += "\n" + 2 * INDENT
+            out += "</div>"
+    
     out += "\n"
     out += "</div>"
     

--- a/builder/make_cards.py
+++ b/builder/make_cards.py
@@ -188,6 +188,8 @@ def dict_to_html(card, category, colour):
             out += loc
             out += "\n" + 2 * INDENT
             out += "</div>"
+        out += "\n" + INDENT
+        out += "</div>"
     
     out += "\n"
     out += "</div>"

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -22,3 +22,20 @@
 .input-field .prefix.active {
     color: #90caf9;
 }
+
+.beans {
+  margin: 0px 0px 10px 20px;
+}
+
+.bean{
+  height: 20px;
+  line-height: 20px;
+  background: gray;
+  text-align: center;
+  display: inline-block;
+  padding: 0px 8px 0px 8px;
+  border-radius: 15px;
+  position: relative;
+  margin: 0px 3px 5px 0px;
+  font-size: 80%;
+}


### PR DESCRIPTION
This update is to keep the St Andrews fork up to date with my master changes. Cards with assigned geographical categories now display these in little bean-shaped icons at the bottom of each card.

Possible future improvements include:
- Clicking on a bean filters by that category
- Create a configuration file that allows geo categories to not be displayed during the card building process